### PR TITLE
feat: Add drag and drop for files and folders

### DIFF
--- a/src/DownloadList.tsx
+++ b/src/DownloadList.tsx
@@ -176,7 +176,18 @@ export const FileItemComponent = ({
   };
 
   return (
-    <li className="flex items-center justify-between p-2 gap-2 bg-gray-50 rounded">
+    <li
+      className="flex items-center justify-between p-2 gap-2 bg-gray-50 rounded"
+      draggable={isInOPFS}
+      onDragStart={(e) => {
+        if (!isInOPFS) return;
+        e.dataTransfer.setData(
+          "application/json",
+          JSON.stringify({ name: file.handle.name, type: "file" })
+        );
+        e.dataTransfer.effectAllowed = "move";
+      }}
+    >
       <span className="text-ellipsis max-w-full break-words">{file.path}</span>
       <div className="flex items-center flex-wrap gap-2">
         <FileSizeComponent />

--- a/src/OPFSList.tsx
+++ b/src/OPFSList.tsx
@@ -190,6 +190,51 @@ export const OPFSList: React.FC = () => {
     }
   }
 
+  async function handleDrop(
+    e: React.DragEvent<HTMLLIElement>,
+    destinationHandle: FileSystemDirectoryHandle
+  ) {
+    e.preventDefault();
+    if (!directoryStackRef.current) return;
+
+    const item = e.dataTransfer.getData("application/json");
+    if (!item) return;
+
+    const { name, type } = JSON.parse(item);
+    const opfs = new OPFS(directoryStackRef.current.currentDirectory);
+    const handle = directoryContents.find(
+      (item) => item.handle.name === name && item.type === type
+    )?.handle;
+
+    if (!handle) return;
+
+    if (handle.kind === "directory") {
+      if (handle.name === destinationHandle.name) {
+        return;
+      }
+      const isDescendant = await FileSystemManager.isDescendant(
+        handle as FileSystemDirectoryHandle,
+        destinationHandle
+      );
+      if (isDescendant) {
+        toaster.danger("Cannot move a folder into one of its subfolders.");
+        return;
+      }
+    }
+
+    if (
+      directoryStackRef.current.currentDirectory.name ===
+      destinationHandle.name
+    ) {
+      return;
+    }
+    await opfs.move(handle, destinationHandle);
+    const entries = await getEntries(
+      directoryStackRef.current.currentDirectory
+    );
+    setDirectoryContents(entries);
+  }
+
   async function createFolder() {
     const folderName = prompt(
       "Enter folder name: (this cannot be changed later"
@@ -294,6 +339,8 @@ export const OPFSList: React.FC = () => {
           onParentFolderSelect={handleParentFolderSelect}
           parentFolderPath={getParentFolderPath()}
           onFolderDownload={handleFolderDownload}
+          onDrop={handleDrop}
+          directoryStack={directoryStackRef.current}
         />
       </div>
     </div>
@@ -315,6 +362,8 @@ const FolderContentsList = ({
   onParentFolderSelect,
   parentFolderPath,
   onFolderDownload,
+  onDrop,
+  directoryStack,
 }: {
   contents: (DirectoryContent | FileContent)[];
   handleFileDelete: (fileItem: FileItem) => void;
@@ -324,6 +373,11 @@ const FolderContentsList = ({
   onFolderDownload: (handle: FileSystemDirectoryHandle) => void;
   onParentFolderSelect: () => void;
   parentFolderPath: string;
+  onDrop: (
+    e: React.DragEvent<HTMLLIElement>,
+    destinationHandle: FileSystemDirectoryHandle
+  ) => void;
+  directoryStack: DirectoryNavigationStack | null;
 }) => {
   const { addFileSize, setFileSizeInDirectory } = useAppStore();
 
@@ -346,6 +400,8 @@ const FolderContentsList = ({
         <p className="text-gray-500 select-none">No files uploaded yet</p>
         <ParentFolderItemComponent
           onParentFolderSelect={onParentFolderSelect}
+          onDrop={onDrop}
+          directoryStack={directoryStack}
         />
       </div>
     );
@@ -353,7 +409,11 @@ const FolderContentsList = ({
 
   return (
     <ul className="space-y-2 max-h-96 overflow-y-auto">
-      <ParentFolderItemComponent onParentFolderSelect={onParentFolderSelect} />
+      <ParentFolderItemComponent
+        onParentFolderSelect={onParentFolderSelect}
+        onDrop={onDrop}
+        directoryStack={directoryStack}
+      />
       {contents.map((item) => {
         if (item.type === "folder") {
           return (
@@ -363,6 +423,7 @@ const FolderContentsList = ({
               onFolderDelete={onFolderDelete}
               onFolderSelect={onFolderSelect}
               onFolderDownload={onFolderDownload}
+              onDrop={onDrop}
             />
           );
         } else {
@@ -389,11 +450,16 @@ const FolderItemComponent = ({
   onFolderDelete,
   onFolderSelect,
   onFolderDownload,
+  onDrop,
 }: {
   handle: FileSystemDirectoryHandle;
   onFolderDelete: (handle: FileSystemDirectoryHandle) => void;
   onFolderSelect: (handle: FileSystemDirectoryHandle) => void;
   onFolderDownload: (handle: FileSystemDirectoryHandle) => void;
+  onDrop: (
+    e: React.DragEvent<HTMLLIElement>,
+    destinationHandle: FileSystemDirectoryHandle
+  ) => void;
 }) => {
   return (
     <li
@@ -402,6 +468,18 @@ const FolderItemComponent = ({
         e.preventDefault();
         e.stopPropagation();
         onFolderSelect(handle);
+      }}
+      draggable
+      onDragStart={(e) => {
+        e.dataTransfer.setData(
+          "application/json",
+          JSON.stringify({ name: handle.name, type: "folder" })
+        );
+        e.dataTransfer.effectAllowed = "move";
+      }}
+      onDrop={(e) => onDrop(e, handle)}
+      onDragOver={(e) => {
+        e.preventDefault();
       }}
     >
       <div className="flex items-center gap-x-2">
@@ -443,8 +521,15 @@ const FolderItemComponent = ({
 
 export const ParentFolderItemComponent = ({
   onParentFolderSelect,
+  onDrop,
+  directoryStack,
 }: {
   onParentFolderSelect: () => void;
+  onDrop: (
+    e: React.DragEvent<HTMLLIElement>,
+    destinationHandle: FileSystemDirectoryHandle
+  ) => void;
+  directoryStack: DirectoryNavigationStack | null;
 }) => {
   return (
     <li
@@ -453,6 +538,17 @@ export const ParentFolderItemComponent = ({
         e.preventDefault();
         e.stopPropagation();
         onParentFolderSelect();
+      }}
+      onDrop={(e) => {
+        if (directoryStack && !directoryStack.isRoot) {
+          const parentHandle = directoryStack.parentDirectoryHandle;
+          if (parentHandle) {
+            onDrop(e, parentHandle);
+          }
+        }
+      }}
+      onDragOver={(e) => {
+        e.preventDefault();
       }}
     >
       <div className="flex items-center gap-x-2">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added drag-and-drop to move files and folders within the in-browser file system, including dragging file items when stored in the OPFS.
  - Drag payloads are encoded as JSON and treated as “move”; folders and the parent directory are valid drop targets.
  - Directory listings refresh automatically after moves.

- Bug Fixes
  - Blocks invalid moves: into the same directory, into an item’s own subfolder, or into itself.
  - Shows clear user-facing error messages for blocked or failed moves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->